### PR TITLE
Properly parse .pth files. Modify pythonpath before tests are imported

### DIFF
--- a/pytest_pythonpath.py
+++ b/pytest_pythonpath.py
@@ -1,15 +1,16 @@
-import sys
 import os
+import site
+import sys
 
 
 def pytest_addoption(parser):
     # py.test has an issue where the cwd is not in the PYTHONPATH. Fix it here.
     if os.getcwd() not in sys.path:
-        sys.path.insert(0, os.getcwd())
+        site.addsitedir(os.getcwd())
     parser.addini("python_paths", type="pathlist", help="space seperated directory paths to add to PYTHONPATH",
                   default=[])
 
 
-def pytest_configure(config):
-    for path in config.getini("python_paths"):
-        sys.path.append(str(path))
+def pytest_load_initial_conftests(args, early_config, parser):
+    for path in early_config.getini("python_paths"):
+        site.addsitedir(str(path))


### PR DESCRIPTION
Tried to use this package and it wasn't working, found two issues:
1) Directly modifying sys.path doesn't traverse .pth files (see https://docs.python.org/2/library/site.html)
2) pytest_configure doesn't get called early enough for me, had to use pytest_load_initial_conftests.

I don't expect you to accept this pull request due to my second modification (pytest_load_initial_conftests). It's a pretty questionable change, my need for it is the result of a settings.py file that depends on the python path being updated before it's imported.
