### PR TITLE
Append to insert

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Usage
 -----
 
 Add a line in your pytest.ini file with a key of `python_paths` and provide a space seperated list of paths
-you want added to the PYTHONPATH before any tests run:
+you want inserted to the beginning of the PYTHONPATH before any tests run:
 
     [pytest]
     python_paths = your/path/apps your/path/libs

--- a/pytest_pythonpath.py
+++ b/pytest_pythonpath.py
@@ -11,5 +11,5 @@ def pytest_addoption(parser):
 
 
 def pytest_configure(config):
-    for path in config.getini("python_paths"):
-        sys.path.append(str(path))
+    for path in reversed(config.getini("python_paths")):
+        sys.path.insert(0, str(path))

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     name='pytest-pythonpath',
     description=description,
     long_description=long_description,
-    version='0.3',
+    version='0.4',
     author='Eric Palakovich Carr',
     author_email='carreric@gmail.com',
     url='https://github.com/bigsassy/pytest-pythonpath',


### PR DESCRIPTION
when some body use pytest-pythonpath, `insert` path is more useful than `append`.
Could we change for that?
