### PR TITLE
Use earlier pytest hook

### DIFF
--- a/pytest_pythonpath.py
+++ b/pytest_pythonpath.py
@@ -13,8 +13,8 @@ def pytest_addoption(parser):
                   default=[])
 
 
-def pytest_configure(config):
-    for path in reversed(config.getini("python_paths")):
+def pytest_load_initial_conftests(args, early_config, parser):
+    for path in reversed(early_config.getini("python_paths")):
         sys.path.insert(0, str(path))
-    for path in config.getini("site_dirs"):
+    for path in early_config.getini("site_dirs"):
         site.addsitedir(str(path))


### PR DESCRIPTION
I was attempting to use pytest-pythonpath in conjunction with pytest-django but I ran into an issue.

The pytest-django plugin needs the `PYTHONPATH` to be modified *before* it's configured.

pytest-pythonpath currently uses the `pytest_configure` hook but this runs *after* all plugins are configured -- too late.

I've modified pytest-pythonpath to use a different hook, `pytest_load_initial_conftests`, which allows plugins to take advantage of  `PYTHONPATH` modifications and shouldn't affect existing projects.

This hook is called before CLI options are parsed but these aren't used.