### PR TITLE
Specify the encoding of the README/long_description

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@ setup(
     name='pytest-pythonpath',
     description=description,
     long_description=long_description,
+    long_description_content_type='text/markdown',
     license='MIT',
     version='0.7.3',
     author='Eric Palakovich Carr',


### PR DESCRIPTION
PyPI defaults to reStructuredText, but the README is Markdown. This causes rendering issues at https://pypi.org/project/pytest-pythonpath/.